### PR TITLE
fix(config.md): added gersemi args `-` to accept input from stdin

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -72,6 +72,7 @@ line_words_max = 100
 [format]
 # Format with an external formatter.
 program = "gersemi"
+args = ["-"]
 ```
 
 ### `args`
@@ -85,5 +86,5 @@ program = "gersemi"
 [format]
 program = "gersemi"
 # Use two space indentation.
-args = ["--indent", "2"]
+args = ["-", "--indent", "2"]
 ```


### PR DESCRIPTION
If the argument `-` is omitted, the file is replaced with an empty file.
We need to pass `-` to `gersemi` so that it reads input from `stdin`.